### PR TITLE
add OfflinePlayerManager for caching offline player lookups

### DIFF
--- a/plugin/pom.xml
+++ b/plugin/pom.xml
@@ -157,6 +157,13 @@
         </dependency>
 
         <dependency>
+            <groupId>com.github.ben-manes.caffeine</groupId>
+            <artifactId>caffeine</artifactId>
+            <version>${caffeine.version}</version>
+            <scope>compile</scope>
+        </dependency>
+
+        <dependency>
             <groupId>org.bstats</groupId>
             <artifactId>bstats-bukkit</artifactId>
             <version>3.2.1</version>

--- a/plugin/src/main/java/me/hsgamer/topper/spigot/plugin/TopperPlugin.java
+++ b/plugin/src/main/java/me/hsgamer/topper/spigot/plugin/TopperPlugin.java
@@ -18,12 +18,12 @@ import me.hsgamer.topper.spigot.plugin.config.MessageConfig;
 import me.hsgamer.topper.spigot.plugin.hook.HookSystem;
 import me.hsgamer.topper.spigot.plugin.listener.JoinListener;
 import me.hsgamer.topper.spigot.plugin.manager.PermissionCheckManager;
+import me.hsgamer.topper.spigot.plugin.manager.OfflinePlayerManager;
 import me.hsgamer.topper.spigot.plugin.manager.ValueProviderManager;
 import me.hsgamer.topper.spigot.plugin.template.SpigotTopTemplate;
 import me.hsgamer.topper.spigot.template.storagesupplier.SpigotStorageSupplierTemplate;
 import org.bstats.bukkit.Metrics;
 import org.bstats.charts.SingleLineChart;
-import org.bukkit.Bukkit;
 
 import java.util.Arrays;
 import java.util.List;
@@ -38,6 +38,7 @@ public class TopperPlugin extends BasePlugin {
 
                 new ValueProviderManager(),
                 new PermissionCheckManager(),
+                new OfflinePlayerManager(),
 
                 new HookSystem(this),
 
@@ -61,7 +62,7 @@ public class TopperPlugin extends BasePlugin {
     @Override
     public void load() {
         MessageUtils.setPrefix(get(MessageConfig.class)::getPrefix);
-        get(SpigotTopTemplate.class).getNameProviderManager().setDefaultNameProvider(uuid -> Bukkit.getOfflinePlayer(uuid).getName());
+        get(SpigotTopTemplate.class).getNameProviderManager().setDefaultNameProvider(uuid -> get(OfflinePlayerManager.class).getOfflinePlayer(uuid).getName());
     }
 
     @Override

--- a/plugin/src/main/java/me/hsgamer/topper/spigot/plugin/hook/placeholderapi/PlaceholderAPIHook.java
+++ b/plugin/src/main/java/me/hsgamer/topper/spigot/plugin/hook/placeholderapi/PlaceholderAPIHook.java
@@ -3,13 +3,13 @@ package me.hsgamer.topper.spigot.plugin.hook.placeholderapi;
 import io.github.projectunified.minelib.plugin.base.Loadable;
 import me.hsgamer.topper.query.forward.QueryForwardContext;
 import me.hsgamer.topper.spigot.plugin.TopperPlugin;
+import me.hsgamer.topper.spigot.plugin.manager.OfflinePlayerManager;
 import me.hsgamer.topper.spigot.plugin.manager.ValueProviderManager;
 import me.hsgamer.topper.spigot.plugin.template.SpigotTopTemplate;
 import me.hsgamer.topper.spigot.plugin.util.ParseUtil;
 import me.hsgamer.topper.spigot.query.forward.placeholderapi.PlaceholderQueryForwarder;
 import me.hsgamer.topper.spigot.value.placeholderapi.PlaceholderValueProvider;
 import me.hsgamer.topper.value.string.StringDeformatters;
-import org.bukkit.Bukkit;
 
 import java.util.Optional;
 import java.util.UUID;
@@ -35,7 +35,7 @@ public class PlaceholderAPIHook implements Loadable {
             return new PlaceholderValueProvider(placeholder, isOnlineOnly)
                     .thenApply(StringDeformatters.deformatterOrIdentity(map))
                     .thenApply(ParseUtil::parsePlaceholderNumber)
-                    .beforeApply(Bukkit::getOfflinePlayer);
+                    .beforeApply(plugin.get(OfflinePlayerManager.class)::getOfflinePlayer);
         }, "placeholderapi", "placeholder", "papi");
         plugin.get(SpigotTopTemplate.class).getQueryForwardManager().addForwarder(queryForwarder);
     }

--- a/plugin/src/main/java/me/hsgamer/topper/spigot/plugin/listener/JoinListener.java
+++ b/plugin/src/main/java/me/hsgamer/topper/spigot/plugin/listener/JoinListener.java
@@ -2,6 +2,7 @@ package me.hsgamer.topper.spigot.plugin.listener;
 
 import io.github.projectunified.minelib.plugin.listener.ListenerComponent;
 import me.hsgamer.topper.spigot.plugin.TopperPlugin;
+import me.hsgamer.topper.spigot.plugin.manager.OfflinePlayerManager;
 import me.hsgamer.topper.spigot.plugin.template.SpigotTopTemplate;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.player.PlayerJoinEvent;
@@ -15,6 +16,7 @@ public class JoinListener implements ListenerComponent {
 
     @EventHandler
     public void onJoin(PlayerJoinEvent event) {
+        instance.get(OfflinePlayerManager.class).cache(event.getPlayer());
         instance.get(SpigotTopTemplate.class).getTopManager().create(event.getPlayer().getUniqueId());
     }
 }

--- a/plugin/src/main/java/me/hsgamer/topper/spigot/plugin/manager/OfflinePlayerManager.java
+++ b/plugin/src/main/java/me/hsgamer/topper/spigot/plugin/manager/OfflinePlayerManager.java
@@ -1,0 +1,62 @@
+package me.hsgamer.topper.spigot.plugin.manager;
+
+import com.github.benmanes.caffeine.cache.Caffeine;
+import com.github.benmanes.caffeine.cache.LoadingCache;
+import io.github.projectunified.minelib.plugin.base.Loadable;
+import org.bukkit.Bukkit;
+import org.bukkit.OfflinePlayer;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.UUID;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * A manager that caches {@link OfflinePlayer} lookups using Caffeine to avoid
+ * repeated (and potentially blocking) calls to {@link Bukkit#getOfflinePlayer(UUID)}.
+ */
+public class OfflinePlayerManager implements Loadable {
+    private final LoadingCache<UUID, OfflinePlayer> cache = Caffeine.newBuilder()
+            .maximumSize(10_000)
+            .expireAfterWrite(10, TimeUnit.MINUTES)
+            .build((UUID uuid) -> Bukkit.getOfflinePlayer(uuid));
+
+    /**
+     * Get the offline player from the cache, loading (and blocking) it if it is not cached yet.
+     *
+     * @param uuid the unique id of the player
+     * @return the offline player
+     */
+    @NotNull
+    public OfflinePlayer getOfflinePlayer(@NotNull UUID uuid) {
+        return cache.get(uuid);
+    }
+
+    /**
+     * Get the offline player only if it is already cached, without triggering a blocking lookup.
+     *
+     * @param uuid the unique id of the player
+     * @return the cached offline player, or {@code null} if it is not cached
+     */
+    @Nullable
+    public OfflinePlayer getOfflinePlayerIfCached(@NotNull UUID uuid) {
+        return cache.getIfPresent(uuid);
+    }
+
+    /**
+     * Put an offline player into the cache.
+     *
+     * @param player the offline player
+     */
+    public void cache(@Nullable OfflinePlayer player) {
+        if (player != null) {
+            cache.put(player.getUniqueId(), player);
+        }
+    }
+
+    @Override
+    public void disable() {
+        cache.invalidateAll();
+    }
+}
+

--- a/pom.xml
+++ b/pom.xml
@@ -51,6 +51,7 @@
         <minelib.version>1.3.0</minelib.version>
         <topper.version>4.19.1</topper.version>
         <core.version>4.8.1</core.version>
+        <caffeine.version>2.9.3</caffeine.version>
         <java.version>1.8</java.version>
     </properties>
 

--- a/query-forward/placeholderapi/pom.xml
+++ b/query-forward/placeholderapi/pom.xml
@@ -29,5 +29,11 @@
             <artifactId>topper-spigot-query-forward-plugin</artifactId>
             <version>${project.version}</version>
         </dependency>
+        <dependency>
+            <groupId>com.github.ben-manes.caffeine</groupId>
+            <artifactId>caffeine</artifactId>
+            <version>${caffeine.version}</version>
+            <scope>compile</scope>
+        </dependency>
     </dependencies>
 </project>

--- a/query-forward/placeholderapi/src/main/java/me/hsgamer/topper/spigot/query/forward/placeholderapi/PlaceholderQueryForwarder.java
+++ b/query-forward/placeholderapi/src/main/java/me/hsgamer/topper/spigot/query/forward/placeholderapi/PlaceholderQueryForwarder.java
@@ -1,5 +1,7 @@
 package me.hsgamer.topper.spigot.query.forward.placeholderapi;
 
+import com.github.benmanes.caffeine.cache.Cache;
+import com.github.benmanes.caffeine.cache.Caffeine;
 import me.clip.placeholderapi.expansion.PlaceholderExpansion;
 import me.hsgamer.topper.query.forward.QueryForwardContext;
 import me.hsgamer.topper.spigot.query.forward.plugin.PluginContext;
@@ -10,11 +12,16 @@ import org.jetbrains.annotations.NotNull;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
+import java.util.concurrent.TimeUnit;
 import java.util.function.Consumer;
 
 public class PlaceholderQueryForwarder<C extends QueryForwardContext<UUID>> implements Consumer<C> {
     private final List<PlaceholderExpansion> expansions = new ArrayList<>();
     private final Plugin defaultPlugin;
+    private final Cache<String, String> resultCache = Caffeine.newBuilder()
+            .maximumSize(10_000)
+            .expireAfterWrite(1, TimeUnit.SECONDS)
+            .build();
 
     public PlaceholderQueryForwarder(Plugin defaultPlugin) {
         this.defaultPlugin = defaultPlugin;
@@ -46,7 +53,9 @@ public class PlaceholderQueryForwarder<C extends QueryForwardContext<UUID>> impl
 
             @Override
             public String onRequest(OfflinePlayer player, @NotNull String params) {
-                return context.getQuery().apply(player != null ? player.getUniqueId() : null, params).result;
+                UUID uuid = player != null ? player.getUniqueId() : null;
+                String cacheKey = context.getName() + '\u0000' + params + '\u0000' + uuid;
+                return resultCache.get(cacheKey, key -> context.getQuery().apply(uuid, params).result);
             }
         };
         expansion.register();
@@ -56,5 +65,6 @@ public class PlaceholderQueryForwarder<C extends QueryForwardContext<UUID>> impl
     public void unregister() {
         expansions.forEach(PlaceholderExpansion::unregister);
         expansions.clear();
+        resultCache.invalidateAll();
     }
 }


### PR DESCRIPTION
This pull request introduces a new `OfflinePlayerManager` to cache `OfflinePlayer` lookups using Caffeine, reducing blocking calls to Bukkit and improving performance. It updates all usages of `Bukkit.getOfflinePlayer` to use this manager, and also adds Caffeine-based caching for PlaceholderAPI query results. Several new dependencies are added to support these changes.

**Caching improvements:**

* Introduced `OfflinePlayerManager`, which uses a Caffeine cache to store and retrieve `OfflinePlayer` instances, minimizing repeated and potentially blocking lookups. (`plugin/src/main/java/me/hsgamer/topper/spigot/plugin/manager/OfflinePlayerManager.java`)
* Updated all usages of `Bukkit.getOfflinePlayer` in the plugin to use `OfflinePlayerManager`, including in the default name provider, PlaceholderAPI hook, and player join listener. (`TopperPlugin.java`, `PlaceholderAPIHook.java`, `JoinListener.java`) [[1]](diffhunk://#diff-486d7bb1c7a3ee3de30845f3ce76ec194b5b4685f1baf3d3533757112173222fL64-R65) [[2]](diffhunk://#diff-db24b6d888b7fedeb05d3a60fbd85a20ca333e7fada10e4f24920eb302c00008L38-R38) [[3]](diffhunk://#diff-ad2fb1f3fa09fdb366a75e2bafde6cf25cc59ffe32f9a7aaeb355dd3f3b978daR19)

**PlaceholderAPI query result caching:**

* Added a short-lived (1 second) Caffeine cache to `PlaceholderQueryForwarder` to cache PlaceholderAPI query results, reducing redundant computations and improving performance. (`PlaceholderQueryForwarder.java`) [[1]](diffhunk://#diff-5aa389497a70cf2d347dcd9660fc4049dc7198e1b46d3ecf9ab6b0c078fd4e38R15-R24) [[2]](diffhunk://#diff-5aa389497a70cf2d347dcd9660fc4049dc7198e1b46d3ecf9ab6b0c078fd4e38L49-R58) [[3]](diffhunk://#diff-5aa389497a70cf2d347dcd9660fc4049dc7198e1b46d3ecf9ab6b0c078fd4e38R68)

**Dependency updates:**

* Added Caffeine as a dependency in relevant `pom.xml` files and defined its version in the root `pom.xml`. (`pom.xml`, `plugin/pom.xml`, `query-forward/placeholderapi/pom.xml`) [[1]](diffhunk://#diff-9c5fb3d1b7e3b0f54bc5c4182965c4fe1f9023d449017cece3005d3f90e8e4d8R54) [[2]](diffhunk://#diff-0b2f1e793aa9ad4aef151dba847084ec8fce8d49fe5ae1925313e2f66f018962R159-R165) [[3]](diffhunk://#diff-3d4d967c9dd98e5ad14c37fb309f42b14f79890c2396baae70eb0202788619aeR32-R37)